### PR TITLE
feat: Add Twitch social link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   IconBrandLinkedin,
   IconBrandSteam,
   IconBrandThreads,
+  IconBrandTwitch,
   IconMail,
   IconMapPin
 } from '@tabler/icons-react';
@@ -94,6 +95,12 @@ export default function Homepage() {
           href=''
           icon={<IconBrandDiscord stroke={2} width='1em' height='1em' />}
           text='nathanialf'
+        />
+        <SocialLink
+          encoded
+          href='https://www.twitch.tv/nathanialfine'
+          icon={<IconBrandTwitch stroke={2} width='1em' height='1em' />}
+          text='nathanialfine'
         />
         <SocialLink
           encoded


### PR DESCRIPTION
Added a new SocialLink for Twitch to the homepage. The link points to https://www.twitch.tv/nathanialfine and uses the Twitch icon from Tabler Icons.